### PR TITLE
Updated common _get_literal()

### DIFF
--- a/pypicosdk/common.py
+++ b/pypicosdk/common.py
@@ -86,6 +86,8 @@ def _struct_to_dict(struct_instance: ctypes.Structure, format=False) -> dict:
 def _get_literal(variable:str, map:dict):
     """Checks if typing Literal variable is in corresponding map
     and returns enum integer value"""
+    if type(variable) is not str:
+        return variable
     if variable in map:
         return map[variable]
     else:


### PR DESCRIPTION
When using new function _get_literal() but using an Enum, the _get_literal would raise an error.
Instead _get_literal checks if type is str and if not, returns the same variable value.