### PR TITLE
Add macOS library path resolution for PicoSDK.framework

### DIFF
--- a/pypicosdk/base.py
+++ b/pypicosdk/base.py
@@ -56,7 +56,12 @@ class PicoScopeBase:
             else:
                 lib_name = "lib" + dll_name + ".so"  # Default to Unix-like naming
 
-            self.dll = ctypes.CDLL(os.path.join(_get_lib_path(), lib_name))
+            lib_dir = _get_lib_path()
+            lib_path = os.path.join(lib_dir, lib_name)
+            if system == "Darwin" and not os.path.exists(lib_path):
+                # PicoSDK.framework stores each lib in its own subdirectory
+                lib_path = os.path.join(lib_dir, lib_name.removesuffix('.dylib'), lib_name)
+            self.dll = ctypes.CDLL(lib_path)
         self._unit_prefix_n = dll_name
 
         # Setup class variables

--- a/pypicosdk/common.py
+++ b/pypicosdk/common.py
@@ -86,7 +86,15 @@ def _get_lib_path() -> str:
     elif system == "Linux":
         return _check_path('/opt', ['picoscope/lib'])
     elif system == "Darwin":
-        raise PicoSDKException("macOS is not yet tested and supported")
+        framework_libs = '/Library/Frameworks/PicoSDK.framework/Libraries'
+        if os.path.exists(framework_libs):
+            return framework_libs
+        checklist = [
+            'PicoScope 7 T&M.app/Contents/Resources',
+            'PicoScope 7 T&M Early Access.app/Contents/Resources',
+            'PicoScope 7 T&M Stable.app/Contents/Resources',
+        ]
+        return _check_path('/Applications', checklist)
     else:
         raise PicoSDKException("Unsupported OS")
 


### PR DESCRIPTION
Replaces the "not supported" exception with framework and app bundle path detection on Darwin, and handles the per-lib subdirectory layout inside PicoSDK.framework.