### PR TITLE
Fix ps5000a power-source handshake for USB-3-on-USB-2 (286) and warn …

### DIFF
--- a/pypicosdk/_drivers/_ps5000a.py
+++ b/pypicosdk/_drivers/_ps5000a.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     from typing_extensions import override  # type: ignore
 from warnings import warn
-from .._exceptions import NoArgumentsNeededWarning
+from .._exceptions import NoArgumentsNeededWarning, PowerSourceWarning
 
 import queue
 
@@ -49,10 +49,28 @@ class ps5000a(PicoScopeBase, Sharedps5000aPs6000a):  # pylint: disable=C0103
             serial_number,
             resolution
         )
+        # ps5000a OpenUnit returns 282 (USB-only) or 286 (USB-3 device on USB-2
+        # port) as prompts requiring acknowledgement via ChangePowerSource before
+        # the device is usable. Both restrict the unit to 2-channel operation.
         if status == cst.POWER_SOURCE.SUPPLY_NOT_CONNECTED:
+            warn(
+                'ps5000a opened without DC power supply — running on USB power, '
+                'restricted to 2-channel operation. Connect the supplied AC '
+                'adapter to enable all channels.',
+                PowerSourceWarning,
+            )
             self.ac_adaptor = False
-            self.change_power_source(cst.POWER_SOURCE.SUPPLY_NOT_CONNECTED)
-            
+            self.change_power_source(status)
+        elif status == cst.POWER_SOURCE.USB3_0_DEVICE_NON_USB3_0_PORT:
+            warn(
+                'ps5000a is a USB 3.0 device plugged into a non-USB-3.0 port — '
+                'restricted to 2-channel operation. Move to a USB 3.0 port to '
+                'enable all channels.',
+                PowerSourceWarning,
+            )
+            self.ac_adaptor = False
+            self.change_power_source(status)
+
         self.resolution = resolution
         self.min_adc_value, self.max_adc_value = self.get_adc_limits()
         self.set_all_channels_off()
@@ -105,10 +123,9 @@ class ps5000a(PicoScopeBase, Sharedps5000aPs6000a):  # pylint: disable=C0103
             power_source (str | POWER_SOURCE): Power source selection.
         """
         power_source = _get_literal(power_source, cst.PwrSrc_M)
-        if power_source == cst.POWER_SOURCE.SUPPLY_NOT_CONNECTED:
-            self.ac_adaptor = False
-        else:
-            self.ac_adaptor = True
+        # 282 (USB-only) and 286 (USB-3 on USB-2 port) both restrict the unit
+        # to a 2-channel feature set, equivalent to running without the AC PSU.
+        self.ac_adaptor = power_source == cst.POWER_SOURCE.SUPPLY_CONNECTED
         self._call_attr_function(
             'ChangePowerSource',
             self.handle,

--- a/pypicosdk/_drivers/_ps5000a.py
+++ b/pypicosdk/_drivers/_ps5000a.py
@@ -58,6 +58,7 @@ class ps5000a(PicoScopeBase, Sharedps5000aPs6000a):  # pylint: disable=C0103
                 'restricted to 2-channel operation. Connect the supplied AC '
                 'adapter to enable all channels.',
                 PowerSourceWarning,
+                stacklevel=2,
             )
             self.ac_adaptor = False
             self.change_power_source(status)
@@ -67,6 +68,7 @@ class ps5000a(PicoScopeBase, Sharedps5000aPs6000a):  # pylint: disable=C0103
                 'restricted to 2-channel operation. Move to a USB 3.0 port to '
                 'enable all channels.',
                 PowerSourceWarning,
+                stacklevel=2,
             )
             self.ac_adaptor = False
             self.change_power_source(status)
@@ -74,6 +76,16 @@ class ps5000a(PicoScopeBase, Sharedps5000aPs6000a):  # pylint: disable=C0103
         self.resolution = resolution
         self.min_adc_value, self.max_adc_value = self.get_adc_limits()
         self.set_all_channels_off()
+
+        if self.ac_adaptor:
+            usb_version = self.get_unit_info(cst.UNIT_INFO.PICO_USB_VERSION)
+            if usb_version != '3.0':
+                warn(
+                    f'ps5000a is connected to a USB {usb_version} port — '
+                    'for maximum data transfer performance, use a USB 3.0 port.',
+                    PowerSourceWarning,
+                    stacklevel=2,
+                )
 
         return status
 

--- a/pypicosdk/_exceptions.py
+++ b/pypicosdk/_exceptions.py
@@ -14,3 +14,7 @@ class PicoSDKNotFoundException(Exception):
 
 class NoArgumentsNeededWarning(UserWarning):
     "Warning no arguments needed for the function."
+
+
+class PowerSourceWarning(UserWarning):
+    "Warning that the device opened in a restricted power-source mode."

--- a/pypicosdk/base.py
+++ b/pypicosdk/base.py
@@ -112,7 +112,8 @@ class PicoScopeBase:
             # 407 - Pico Waiting For Data Buffers
             # 282 - Pico Power Supply Not Connected
             # 290 - Pico Channel Disabled Due To Usb Powered
-            if status in [407, 282, 290, 39]:
+            # 286 - Pico Usb3 0 Device Non Usb3 0 Port (ps5000a: handled in open_unit)
+            if status in [407, 282, 286, 290, 39]:
                 return
             self.close_unit()
             raise PicoSDKException(error_code)

--- a/pypicosdk/base.py
+++ b/pypicosdk/base.py
@@ -110,10 +110,11 @@ class PicoScopeBase:
             # Ignore codes as they are warnings or status updates.
             # 39 - Pico Busy
             # 407 - Pico Waiting For Data Buffers
+            # 281 - Pico Power Supply Connected (returned by CurrentPowerSource / ChangePowerSource)
             # 282 - Pico Power Supply Not Connected
             # 290 - Pico Channel Disabled Due To Usb Powered
-            # 286 - Pico Usb3 0 Device Non Usb3 0 Port (ps5000a: handled in open_unit)
-            if status in [407, 282, 286, 290, 39]:
+            # 286 - Pico Usb3 0 Device Non Usb3 0 Port (ps5000a: warns in open_unit)
+            if status in [407, 281, 282, 286, 290, 39]:
                 return
             self.close_unit()
             raise PicoSDKException(error_code)


### PR DESCRIPTION
…user

OpenUnit returning status 286 (USB 3.0 device on a non-USB-3.0 port) was treated as a hard error by _error_handler, which called close_unit and raised PicoSDKException. The legacy picosdk-python-wrappers expected the caller to acknowledge 286 the same way as 282 via ChangePowerSource; in the new wrapper only 282 was handled.

- Add 286 to the _error_handler ignore list in base.py so it propagates back to ps5000a.open_unit for handshaking.
- ps5000a.open_unit now branches on 282 and 286, calls change_power_source with the returned status, and emits a PowerSourceWarning explaining which restricted mode the unit is in.
- New PowerSourceWarning(UserWarning) in _exceptions, so users can filter or suppress these specifically.
- Simplify ac_adaptor flag in change_power_source: only SUPPLY_CONNECTED enables the full channel set; 282 and 286 are both 2-channel modes.