### PR TITLE
Fix set_trigger_channel_properties function (API break)

### DIFF
--- a/pypicosdk/base.py
+++ b/pypicosdk/base.py
@@ -1215,37 +1215,28 @@ class PicoScopeBase:
 
     def set_trigger_channel_properties(
         self,
-        threshold_upper: int,
-        hysteresis_upper: int,
-        threshold_lower: int,
-        hysteresis_lower: int,
-        channel: int,
+        properties: list[tuple[int, int, int, int, int | CHANNEL]],
         aux_output_enable: int = 0,
         auto_trigger_us: int = 0,
     ) -> None:
-        """Configure trigger thresholds for ``channel``. All threshold and hysteresis values are
-        specified in ADC counts.
-        Be aware if using raw ADC values, threshold is always scaled to a 16-bit ADC value,
-        (Even when using 8-bit resolution).
+        """Configure trigger thresholds for multiple channels. All threshold and
+        hysteresis values are specified in ADC counts.
+        Be aware if using raw ADC values, threshold is always scaled to a 16-bit ADC
+        value, even when using 8-bit resolution.
 
         Args:
-            threshold_upper (int): Upper trigger level.
-            hysteresis_upper (int): Hysteresis for ``threshold_upper``.
-            threshold_lower (int): Lower trigger level.
-            hysteresis_lower (int): Hysteresis for ``threshold_lower``.
-            channel (int): Target channel as a :class:`CHANNEL` value.
+            properties (list[tuple[int, int, int, int, int | CHANNEL]]): A list of
+                tuples describing trigger parameters for a specific channel. Parameters
+                are ordered as follow: upper trigger level, upper trigger hysteresis,
+                lower trigger level, lower trigger hysteresis, channel.
             aux_output_enable (int, optional): Auxiliary output flag.
             auto_trigger_us (int, optional): Auto-trigger timeout in
                 microseconds. ``0`` waits indefinitely.
         """
-
-        prop = PICO_TRIGGER_CHANNEL_PROPERTIES(
-            threshold_upper,
-            hysteresis_upper,
-            threshold_lower,
-            hysteresis_lower,
-            channel,
-        )
+        prop_len = len(properties)
+        prop_array = (PICO_TRIGGER_CHANNEL_PROPERTIES * prop_len)()
+        for i, args in enumerate(properties):
+            prop_array[i] = PICO_TRIGGER_CHANNEL_PROPERTIES(*args)
 
         if self._unit_prefix_n == "ps5000a":
             call_function = "SetTriggerChannelPropertiesV2"
@@ -1255,7 +1246,7 @@ class PicoScopeBase:
         self._call_attr_function(
             call_function,
             self.handle,
-            ctypes.byref(prop),
+            ctypes.byref(prop_array),
             ctypes.c_int16(1),
             ctypes.c_int16(aux_output_enable),
             ctypes.c_uint32(auto_trigger_us),


### PR DESCRIPTION
Hi,

I'm creating a pull request here because it seems the issue tracker isn't available for this repo. Please feel free to remove this PR if you think this is inapropriate.

## Issue

We are actually working with a ps3417E and the recommended `psopsa` API. We need to trigger on a falling edge either on channel A or channel B. As described in the programmer's guide, we have called two times the `set_trigger_channel_conditions()` function (OR behaviour), then `set_trigger_channel_directions()` function, and finally the `set_trigger_channel_properties()` function.

Unfortunatly the latter is not alligned with the programmer's guide and only allows the user to configure the properties of a single channel. We tried to call this function twice - once for channel A and once for channel B - but it seems to just write/overwrite the same internal states. In fact, when calling any `run_xxx` function, an error is raised indicating that the conditions were set correctly but the properties were not.

### Pseudo code example:

```python

import pypicosdk as psdk
from pypicosdk.constants import (
    CHANNEL,
    TRIGGER_STATE,
    ACTION,
    THRESHOLD_DIRECTION,
    THRESHOLD_MODE,
)

# Picoscope PS3417E Initialisation
pico: psdk.psospa.psospa = psdk.psospa()
pico.open_unit()

# Enable channel A and B.
pico.set_channel(channel=CHANNEL.A)
pico.set_channel(channel=CHANNEL.B)

# Set trigger conditions.
# We want to trigger an acquisition either on A or B falling edge.
pico.set_trigger_channel_conditions(
    conditions=[(CHANNEL.A, TRIGGER_STATE.TRUE), (CHANNEL.B, TRIGGER_STATE.DONT_CARE)],
    action=ACTION.ADD,
) 
pico.set_trigger_channel_conditions(
    conditions=[(CHANNEL.A, TRIGGER_STATE.DONT_CARE), (CHANNEL.B, TRIGGER_STATE.TRUE)],
    action=ACTION.ADD,
) 

# Set trigger directions (falling edge).
pico.set_trigger_channel_directions(
    channel=[CHANNEL.A, CHANNEL.B],
    direction=[THRESHOLD_DIRECTION.FALLING,  THRESHOLD_DIRECTION.FALLING],
    threshold_mode=[THRESHOLD_MODE.LEVEL, THRESHOLD_MODE.LEVEL],
)

# Set trigger channel properties for channel A.
pico.set_trigger_channel_properties(
    threshold_upper=10000,
    hysteresis_upper=0,
    threshold_lower=0,
    hysteresis_lower=0,
    channel=CHANNEL.A,
    aux_output_enable=0,
    auto_trigger_us=0,
)

# Set trigger channel properties for channel B.
pico.set_trigger_channel_properties(
    threshold_upper=10000,
    hysteresis_upper=0,
    threshold_lower=0,
    hysteresis_lower=0,
    channel=CHANNEL.B,
    aux_output_enable=0,
    auto_trigger_us=0,
)

...

# Raise an error telling that the conditions were set but not the properties.
pico.run_simple_rapid_block_capture(...)

```

## Proposal

The current pull request changes the function signature and allows the user to set properties for multiple channels in one call. Thus, the user is able to use conditions with multiple channels. The downside is that it breaks the current pyPicoSDK API.

### Example:

```python
# properties argument is a list of tuples containing:
# (threshold_upper, hysteresis_upper, threshold_lower, hysteresis_lower, CHANNEL)

pico.set_trigger_channel_properties(
    properties=[
        (10000, 0, 0, 0, CHANNEL.A),
        (10000, 0, 0, 0, CHANNEL.B),
    ],
    aux_output_enable=0,
    auto_trigger_us=0,
)
```

