### PR TITLE
Fix get_trigger_info's segment-counting behavior

### DIFF
--- a/pypicosdk/base.py
+++ b/pypicosdk/base.py
@@ -642,9 +642,13 @@ class PicoScopeBase:
         if self._unit_prefix_n in ['ps5000a']:
             call = "GetTriggerInfoBulk"
             array_struct = cst.PICO_TRIGGER_INFO_PS5000A
+            # Older ps5000a takes an inclusive last index
+            last_argument = first_segment_index + to_segment_index - 1
         else:
             call = "GetTriggerInfo"
             array_struct = cst.PICO_TRIGGER_INFO
+            # Newer models take the count of segments, not an inclusive last index
+            last_argument = to_segment_index
 
         info_array = (array_struct * to_segment_index)()
 
@@ -653,7 +657,7 @@ class PicoScopeBase:
             self.handle,
             ctypes.byref(info_array),
             first_segment_index,
-            first_segment_index + to_segment_index - 1,
+            last_argument,
         )
         # Convert struct to dictionary
         return [_struct_to_dict(info, format=True) for info in info_array]


### PR DESCRIPTION
On psospa/ps6000a devices, `get_trigger_info(first_segment_index,to_segment_index)` (in `base.py`) passes `first_segment_index + to_segment_index - 1` as the fourth arg to the C call. But per the programmer guides for these devices, that argument is supposed `segmentCount`; the old implementation passes the last segment index instead.

For example, for a 1000-waveform block capture, the driver is asked for only 999 segments. So the final segment's `PICO_TRIGGER_INFO` struct is never written [and subsequently comes back as all zeros].

This behavior is apparently only a problem for the psospa/ps6000a devices. (ps5000a _does_ expect an inclusive last index.)